### PR TITLE
waitpid for the man process to exit

### DIFF
--- a/lib/Pod/Perldoc/ToMan.pm
+++ b/lib/Pod/Perldoc/ToMan.pm
@@ -358,6 +358,9 @@ sub _filter_through_nroff {
 		length $done
 		);
 
+	# wait for it to exit
+	waitpid( $pid, 0 );
+
 	if( $? ) {
 		$self->warn( "Error from pipe to $render!\n" );
 		$self->debug( 'Error: ' . do { local $/; <$err> } );


### PR DESCRIPTION
Without waiting on the forked process, we may check the status of the wrong $?.

Fix from millert@openbsd

This happens at least on OpenBSD and I've heard on FreeBSD using mandoc.

http://mandoc.bsd.lv/

```
$ cd Pod-Perldoc
$ PERL5LIB=lib ./perldoc -oMan Digest
Error from pipe to /usr/bin/mandoc!

 at lib/Pod/Perldoc.pm line 1517.
Falling back to Pod because there was a problem!

 at lib/Pod/Perldoc.pm line 1517.
Error while formatting with Pod::Perldoc::ToMan:
 Can't read-open Pod::Perldoc::ToMan=HASH(0x43a208de958): No such file or directory
Aborting
 at lib/Pod/Perldoc/ToMan.pm line 407.


 at ./perldoc line 6.
Got a 0-length file from /usr/libdata/perl5/Digest.pm via Pod::Perldoc::ToMan!?

 at ./perldoc line 6.
```