### PR TITLE
Enable UTF-8 for ToMan if _is_mandoc

### DIFF
--- a/lib/Pod/Perldoc/ToMan.pm
+++ b/lib/Pod/Perldoc/ToMan.pm
@@ -146,6 +146,12 @@ sub _get_podman_switches {
     #
     #push @switches, 'utf8' => 1;
 
+    # mandoc handles UTF-8 input just fine.
+	if ( $self->_is_mandoc ) {
+		push @switches, 'utf8' => 1;
+	}
+
+
 	$self->debug( "Pod::Man switches are [@switches]\n" );
 
 	return @switches;


### PR DESCRIPTION
Everyone should have a mandoc that supports UTF-8 at this point.

See OpenBSD commit to ToMan.pm r1.10, commitid: HlglfXQtZtfN1rcB
http://cvsweb.openbsd.org/src/gnu/usr.bin/perl/cpan/Pod-Perldoc/lib/Pod/Perldoc/ToMan.pm?rev=1.10&content-type=text/x-cvsweb-markup

On Mon, May 06, 2019 at 01:07:02AM +0200, Ingo Schwarze wrote to tech@openbsd:
> Solaris 11 has 1.22 (2013), Solaris 9 has 1.21 (2009), and rumour
> has it that MacOS X might still have 1.19 (2004/05)...
>
> Look at https://mandoc.bsd.lv/ports.html :
> The oldest mandoc still in use anywhere is 1.14.3, on Alpine and
> on Ubuntu-oldstable Aardvark.  Oh wait, Debian-stable Stretch
> still has 1.13.3, but even that should be just fine: according to
> https://mandoc.bsd.lv/devhistory.html , direct UTF-8 input to mandoc
> works since 1.13.2 (Dec. 2014).  Well, DragonFly still has 1.13.1,
> but they are totally outdated anyway and while they do ship an
> ancient mandoc, they don't actually use it for anything.