### PR TITLE
Use `test -e` instead of `test -f`

### DIFF
--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -1810,6 +1810,12 @@ sub containspod {
         return 0;
     }
 
+    if ( -p $file )
+    {
+        $self->warn( "$file is a PIPE/FIFO; assuming it contains POD\n" ) if DEBUG or $self->opt_D;
+        return 1;
+    }
+
     local($_);
     my $fh = $self->open_fh("<", $file);
     while (<$fh>) {

--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -1590,7 +1590,7 @@ sub minus_f_nocase {   # i.e., do like -f, but without regard to case
 
      my($self, $dir, $file) = @_;
      my $path = catfile($dir,$file);
-     return $path if -f $path and -r _;
+     return $path if -e $path and -r _;
 
      if(!$self->opt_i
         or $self->is_vms or $self->is_mswin32
@@ -1598,7 +1598,7 @@ sub minus_f_nocase {   # i.e., do like -f, but without regard to case
      ) {
         # On a case-forgiving file system, or if case is important,
     #  that is it, all we can do.
-    $self->warn( "Ignored $path: unreadable\n" ) if -f _;
+    $self->warn( "Ignored $path: unreadable\n" ) if -e _;
     return '';
      }
 
@@ -1643,8 +1643,8 @@ sub minus_f_nocase {   # i.e., do like -f, but without regard to case
 
         push @p, $cip;
         my $p_filespec = catfile(@p);
-        return $p_filespec if -f $p_filespec and -r _;
-        $self->warn( "Ignored $p_filespec: unreadable\n" ) if -f _;
+        return $p_filespec if -e $p_filespec and -r _;
+        $self->warn( "Ignored $p_filespec: unreadable\n" ) if -e _;
     }
      }
      return "";
@@ -1955,7 +1955,7 @@ sub searchfor {
     my($self, $recurse,$s,@dirs) = @_;
     $s =~ s!::!/!g;
     $s = VMS::Filespec::unixify($s) if $self->is_vms;
-    return $s if -f $s && $self->containspod($s);
+    return $s if -e $s && $self->containspod($s);
     $self->aside( "Looking for $s in @dirs\n" );
     my $ret;
     my $i;

--- a/lib/Pod/Perldoc/ToTerm.pm
+++ b/lib/Pod/Perldoc/ToTerm.pm
@@ -54,7 +54,22 @@ sub _maybe_modify_environment {
 
 }
 
-sub _get_stty { `stty -a` }
+sub _get_stty {
+
+  if ( !-t STDIN && -e "/dev/tty" ) {
+     # I went with this more-baroque method because `local *STDIN`
+     # doesn't stay localized during:  return `stty -a`;
+
+     open my $OLDFH, '<&' => \*STDIN or die "Can't dup STDIN\n";
+     open *STDIN, '<' => "/dev/tty";
+     my $retval = `stty -a`;
+     open *STDIN, '<&' => $OLDFH;
+     return $retval;
+  }
+
+  ### Else...
+  return `stty -a`;
+}
 
 sub _get_columns_from_stty {
 	my $output = $_[0]->_get_stty;


### PR DESCRIPTION
This makes `someCmd | perldoc /dev/stdin` and `perldoc <(someCmd)` Do What I Mean on Unix/Bash-like systems, and I don't expect it shouldn't break any non-Unix systems, either -- though I haven't performed an exhaustive test