### PR TITLE
Don't interpolate program name into sprintf templates, which causes setgid scripts to complain

### DIFF
--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -521,7 +521,7 @@ sub process {
     return $self->usage_brief  unless  @{ $self->{'args'} };
     $self->options_reading;
     $self->pagers_guessing;
-    $self->aside(sprintf "$0 => %s v%s\n", ref($self), $self->VERSION);
+    $self->aside(sprintf "%s => %s v%s\n", $0, ref($self), $self->VERSION);
     $self->drop_privs_maybe unless ($self->opt_U || $self->opt_F);
     $self->options_processing;
 


### PR DESCRIPTION
From https://rt.cpan.org/Ticket/Display.html?id=138932