### PR TITLE
Make perldoc -a somename work again

### DIFF
--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -1258,7 +1258,7 @@ sub search_perlapi {
     while (<$fh>) {
         /^=encoding\s+(\S+)/ && $self->set_encoding($fh, $1);
 
-        if ( m/^=item\s+$search_re\b/ )  {
+        if ( m/^=item\s+(?:C<)?$search_re(?:>)?\b/ )  {
             $found = 1;
         }
         elsif (@related > 1 and /^=item/) {


### PR DESCRIPTION
At some point, perlapi.pod started having symbols wrapped in C<..> tags breaking perldoc -a's functionality.

Allow perldoc -a to work with new style perlapi.pod and old style perlapi.pod